### PR TITLE
Ruby syntax highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 
 ## Usage
 
-```
+```ruby
 class NuclearPowerPlantHealthSummaryGenerator
   def generate(region)
     PiecePipe::Pipeline.new.


### PR DESCRIPTION
highlight the example syntax to make it more readable.